### PR TITLE
fixes a problem with miniseed files that contain traces with different seed_ids

### DIFF
--- a/seishub/plugins/seismology/waveform.py
+++ b/seishub/plugins/seismology/waveform.py
@@ -406,10 +406,6 @@ class WaveformCutterMapper(Component):
                     stream.append(tr)
                 del st
 
-        # Filter in the case it is a multi-component non MiniSEED file.
-        stream = stream.select(network=result[2], station=result[3],
-            location=result[4], channel=result[5])
-
         # pickle stream
         data = pickle.dumps(stream, protocol=2)
         del stream


### PR DESCRIPTION
Miniseed files get indexed for each seed_id they contain. However, during requests, after reading they are not filtered for one seed_id but all traces from the file are returned.

Example:
file contains 1 Z, N, E trace each.

Requests for the Z component return all three components in a Stream, wildcarded requests for all three components return 9 traces (3x all three components).

This is fixed here, possible influences on other file formats were not checked, though.
